### PR TITLE
fix /resources/users/v3 response

### DIFF
--- a/apis-combined.json
+++ b/apis-combined.json
@@ -11202,7 +11202,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserV3Dto"
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/UserV3Dto"
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/identity.json
+++ b/identity.json
@@ -6371,7 +6371,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserV3Dto"
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/UserV3Dto"
+                      }
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
 I noticed that this endpoint (/identity/resources/users/v3) in the API spec is incorrect. Specifically, the 200 response is invalid (see here the exact line). It actually returns a paged result of the entities, not the data as currently described.

e.g. output
```
{
    "_metadata": {
        "totalItems": N,
        "totalPages": M
    },
    "_links": {
        "first": "/?_filter=&_limit=50&_offset=0",
        "last": "/?_filter=&_limit=50&_offset=0"
    },
    "items": [ {...}, {...}, {...} ]. <--- should be like this
}
```